### PR TITLE
Make device fetch independent from device values

### DIFF
--- a/app/src/main/java/hr/fer/fercropmanager/crop/ui/CropContent.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/crop/ui/CropContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -236,6 +237,18 @@ private fun CropDetails(crop: Crop, isShortcutLoading: Boolean, onStartWateringC
                             }
                         }
                     }
+                }
+            }
+        }
+        with(crop) {
+            if (soilMoisture == null && temperature == null && humidity == null) {
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
                 }
             }
         }

--- a/app/src/main/java/hr/fer/fercropmanager/crop/usecase/CropState.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/crop/usecase/CropState.kt
@@ -2,6 +2,7 @@ package hr.fer.fercropmanager.crop.usecase
 
 import hr.fer.fercropmanager.auth.service.AuthState
 import hr.fer.fercropmanager.device.service.Device
+import hr.fer.fercropmanager.device.service.DeviceValues
 
 sealed interface CropState {
 
@@ -45,12 +46,12 @@ enum class Plant {
 
 fun AuthState.Success.toUserData() = UserData(name = name, email = email)
 
-fun Device.toCrop() = Crop(
+fun Device.toCrop(deviceValues: DeviceValues?) = Crop(
     id = id,
     cropName = name,
-    soilMoisture = moisture,
-    temperature = temperature,
-    humidity = humidity,
+    soilMoisture = deviceValues?.moisture,
+    temperature = deviceValues?.temperature,
+    humidity = deviceValues?.humidity,
     wind = Wind(
         direction = WindDirection.East,
         speed = 6f,

--- a/app/src/main/java/hr/fer/fercropmanager/device/api/DeviceDto.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/api/DeviceDto.kt
@@ -2,8 +2,6 @@ package hr.fer.fercropmanager.device.api
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
 data class DeviceDto(
@@ -97,20 +95,3 @@ data class LatestValuesDto(
     val moisture: Long? = null,
     val isWateringInProgress: Boolean = false,
 )
-
-data class DeviceValues(
-    val humidity: Float?,
-    val temperature: Float?,
-    val moisture: Float?,
-    val isWateringInProgress: Boolean,
-)
-
-fun DeviceDataDto.toDeviceValues() = DeviceValues(
-    humidity = data.humidity.floatValue,
-    temperature = data.temperature.floatValue,
-    moisture = data.moisture.floatValue,
-    isWateringInProgress = data.isWateringInProgress,
-)
-
-private val List<List<JsonElement>>?.floatValue: Float?
-    get() = this?.firstOrNull()?.getOrNull(1)?.jsonPrimitive?.contentOrNull?.toFloat()

--- a/app/src/main/java/hr/fer/fercropmanager/device/deviceModule.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/deviceModule.kt
@@ -4,6 +4,8 @@ import hr.fer.fercropmanager.device.api.DeviceApi
 import hr.fer.fercropmanager.device.api.DeviceApiImpl
 import hr.fer.fercropmanager.device.persistence.DevicePersistence
 import hr.fer.fercropmanager.device.persistence.DevicePersistenceImpl
+import hr.fer.fercropmanager.device.persistence.DeviceValuesPersistence
+import hr.fer.fercropmanager.device.persistence.DeviceValuesPersistenceImpl
 import hr.fer.fercropmanager.device.service.DeviceService
 import hr.fer.fercropmanager.device.service.DeviceServiceImpl
 import hr.fer.fercropmanager.device.websocket.DeviceWebSocket
@@ -17,4 +19,5 @@ val deviceModule = module {
     singleOf(::DeviceWebSocketImpl) bind DeviceWebSocket::class
     singleOf(::DeviceServiceImpl) bind DeviceService::class
     singleOf(::DevicePersistenceImpl) bind DevicePersistence::class
+    singleOf(::DeviceValuesPersistenceImpl) bind DeviceValuesPersistence::class
 }

--- a/app/src/main/java/hr/fer/fercropmanager/device/persistence/DevicePersistence.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/persistence/DevicePersistence.kt
@@ -1,12 +1,14 @@
 package hr.fer.fercropmanager.device.persistence
 
 import hr.fer.fercropmanager.device.service.DeviceState
+import hr.fer.fercropmanager.device.service.DeviceValues
 import kotlinx.coroutines.flow.Flow
 
 interface DevicePersistence {
 
-    fun getCachedState(): Flow<DeviceState>
+    fun getCachedDeviceState(): Flow<DeviceState>
     fun getSelectedDeviceId(): Flow<String>
     suspend fun setSelectedDeviceId(entityId: String)
     suspend fun updateDeviceState(deviceState: DeviceState)
+
 }

--- a/app/src/main/java/hr/fer/fercropmanager/device/persistence/DevicePersistenceImpl.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/persistence/DevicePersistenceImpl.kt
@@ -1,15 +1,16 @@
 package hr.fer.fercropmanager.device.persistence
 
 import hr.fer.fercropmanager.device.service.DeviceState
+import hr.fer.fercropmanager.device.service.DeviceValues
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class DevicePersistenceImpl : DevicePersistence {
 
-    private val deviceStateFlow: MutableStateFlow<DeviceState> = MutableStateFlow(DeviceState.Initial)
+    private val cachedDeviceState: MutableStateFlow<DeviceState> = MutableStateFlow(DeviceState.Initial)
     private val selectedDeviceId = MutableStateFlow("")
 
-    override fun getCachedState() = deviceStateFlow.asStateFlow()
+    override fun getCachedDeviceState() = cachedDeviceState.asStateFlow()
 
     override fun getSelectedDeviceId() = selectedDeviceId.asStateFlow()
 
@@ -18,6 +19,6 @@ class DevicePersistenceImpl : DevicePersistence {
     }
 
     override suspend fun updateDeviceState(deviceState: DeviceState) {
-        deviceStateFlow.value = deviceState
+        cachedDeviceState.value = deviceState
     }
 }

--- a/app/src/main/java/hr/fer/fercropmanager/device/persistence/DeviceValuesPersistence.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/persistence/DeviceValuesPersistence.kt
@@ -1,0 +1,10 @@
+package hr.fer.fercropmanager.device.persistence
+
+import hr.fer.fercropmanager.device.service.DeviceValues
+import kotlinx.coroutines.flow.Flow
+
+interface DeviceValuesPersistence {
+
+    fun getCachedDeviceValues(): Flow<Map<String, DeviceValues>>
+    suspend fun updateDeviceValues(deviceValuesMap: Map<String, DeviceValues>)
+}

--- a/app/src/main/java/hr/fer/fercropmanager/device/persistence/DeviceValuesPersistenceImpl.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/persistence/DeviceValuesPersistenceImpl.kt
@@ -1,0 +1,16 @@
+package hr.fer.fercropmanager.device.persistence
+
+import hr.fer.fercropmanager.device.service.DeviceValues
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class DeviceValuesPersistenceImpl : DeviceValuesPersistence {
+
+    private val cachedDeviceValuesMap = MutableStateFlow(mapOf<String, DeviceValues>())
+
+    override fun getCachedDeviceValues() = cachedDeviceValuesMap.asStateFlow()
+
+    override suspend fun updateDeviceValues(deviceValuesMap: Map<String, DeviceValues>) {
+        cachedDeviceValuesMap.value = deviceValuesMap
+    }
+}

--- a/app/src/main/java/hr/fer/fercropmanager/device/service/DeviceService.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/service/DeviceService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface DeviceService {
 
     fun getDeviceState(): Flow<DeviceState>
-    suspend fun refreshDeviceState()
+    fun getDeviceValues(): Flow<Map<String, DeviceValues>>
+    suspend fun refreshDevices()
     suspend fun startActuation(targetValue: String)
 }

--- a/app/src/main/java/hr/fer/fercropmanager/device/service/DeviceState.kt
+++ b/app/src/main/java/hr/fer/fercropmanager/device/service/DeviceState.kt
@@ -1,5 +1,11 @@
 package hr.fer.fercropmanager.device.service
 
+import hr.fer.fercropmanager.device.api.Data
+import hr.fer.fercropmanager.device.api.DeviceDataDto
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
 sealed interface DeviceState {
 
     data object Initial : DeviceState
@@ -15,8 +21,28 @@ sealed interface DeviceState {
 data class Device(
     val id: String,
     val name: String,
-    val temperature: Float?,
-    val humidity: Float?,
-    val moisture: Float?,
+    val type: String,
     val isWateringInProgress: Boolean,
 )
+
+data class DeviceValues(
+    val humidity: Float? = null,
+    val temperature: Float? = null,
+    val moisture: Float? = null,
+)
+
+fun Data.toDevice() = Device(
+    id = id.id,
+    name = name,
+    type = type,
+    isWateringInProgress = false,
+)
+
+fun DeviceDataDto.toDeviceValues() = DeviceValues(
+    humidity = data.humidity.floatValue,
+    temperature = data.temperature.floatValue,
+    moisture = data.moisture.floatValue,
+)
+
+private val List<List<JsonElement>>?.floatValue: Float?
+    get() = this?.firstOrNull()?.getOrNull(1)?.jsonPrimitive?.contentOrNull?.toFloat()


### PR DESCRIPTION
This PR makes fetching devices an independent process from receiving device values through the web socket. Values can now be null, but the devices will still be displayed.